### PR TITLE
Fix numpy dtype

### DIFF
--- a/teras/preprocessing/gain.py
+++ b/teras/preprocessing/gain.py
@@ -101,7 +101,7 @@ class GAINDataTransformer(_BaseDataTransformer):
         # dataset, even to the categorical features we converted using ordinal encoder
         x = x.values
         x = (x - self.min_vals) / self.max_vals
-        x = x.astype(np.float)
+        x = x.astype(np.float32)
 
         # if return_dataframe:
         x = pd.DataFrame(x, columns=self.ordered_features_names_all)


### PR DESCRIPTION
Found a small bug when I was following the imputation example. `np.float` was deprecated in 1.20 and removed at some point - not sure if you want `np.float32` or just `float`.